### PR TITLE
Fix quay docker container uri

### DIFF
--- a/egg-geyser-m-c.json
+++ b/egg-geyser-m-c.json
@@ -3,11 +3,12 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-08-27T15:08:05+01:00",
+    "exported_at": "2020-11-11T19:07:38-05:00",
     "name": "GeyserMC",
     "author": "support@geysermc.org",
     "description": "Geyser is a bridge between Minecraft: Bedrock Edition and Minecraft: Java Edition, closing the gap from those wanting to play true cross-platform.",
-    "image": "quay.io\/geysermc\/pterodactyl-stuff:docker-geyser",
+    "features": null,
+    "image": "quay.io\/geysermc\/pterodactyl-stuff:docker-container",
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"bedrock.address\": \"0.0.0.0\",\r\n            \"bedrock.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
@@ -28,8 +29,8 @@
             "description": "This is the GeyserMC jar.",
             "env_variable": "SERVER_JARFILE",
             "default_value": "Geyser.jar",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
         },
         {
@@ -37,8 +38,8 @@
             "description": "",
             "env_variable": "AUTO_UPDATE",
             "default_value": "1",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|boolean"
         },
         {
@@ -46,8 +47,8 @@
             "description": "The branch to fetch when downloading Geyser",
             "env_variable": "UPDATE_BRANCH",
             "default_value": "master",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         }
     ]


### PR DESCRIPTION
Previously couldn't load the server in panel + wings version 1.1.1. This seems to have fixed it for me.