### PR TITLE
Fix my "Add java.lang.NullPointerException fix"

### DIFF
--- a/egg-geyser-connect.json
+++ b/egg-geyser-connect.json
@@ -12,7 +12,6 @@
     "images": [
         "quay.io\/geysermc\/pterodactyl-stuff:docker-geyserconnect"
     ],
-    "file_denylist": "",
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"address\": \"0.0.0.0\",\r\n            \"port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",


### PR DESCRIPTION
Due to a bug with Pterodactyl Panel, the "file_denylist" line causes a 500 internal server error when importing. This pull request fixes my mistake in my pull request.
My original pull request: #17