### PR TITLE
Fix incorrect image name for java 16 in paper-geyser-floodgate egg

### DIFF
--- a/egg-paper--geyser--floodgate.json
+++ b/egg-paper--geyser--floodgate.json
@@ -12,7 +12,7 @@
         "eula"
     ],
     "images": [
-        "quay.io\/parkervcp\/pterodactyl-images\/debian_openjdk-16",
+        "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-16",
         "quay.io\/pterodactyl\/core:java-11",
         "quay.io\/pterodactyl\/core:java"
     ],

--- a/egg-waterfall--geyser--floodgate.json
+++ b/egg-waterfall--geyser--floodgate.json
@@ -10,7 +10,7 @@
     "description": "Waterfall is a fork of the well-known BungeeCord server teleportation suite.\r\n\r\nThis customization installs the GeyserMC and Floodgate plugins, which allows Bedrock players to connect without needing a Java account.",
     "features": null,
     "images": [
-        "quay.io\/parkervcp\/pterodactyl-images\/debian_openjdk-16",
+        "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-16",
         "quay.io\/pterodactyl\/core:java-11",
         "quay.io\/pterodactyl\/core:java"
     ],


### PR DESCRIPTION
Before, this egg didn't work and wouldn't load - it's because debian_openjdk16 is a tag of pterodactyl-images, not a nested image.

I've only done minimal testing but with this patch the egg actually installs now, whereas previously it wouldn't at all.

I also have not checked to see if the error exists in other eggs. Will do that after I've tested my patch to this egg more.